### PR TITLE
Secure seed compare

### DIFF
--- a/PA193_mnemonic_Slytherin/mnemonic.py
+++ b/PA193_mnemonic_Slytherin/mnemonic.py
@@ -86,7 +86,6 @@ def _secure_seed_compare(expected_seed: bytes, actual_seed: bytes) -> bool:
     :rtype: bool
     :return: True if seeds are the same, False otherwise.
     """
-    # TODO: Can we use `hmac` module?
     # > hmac.compare_digest` uses an approach designed to prevent timing
     # > analysis by avoiding content-based short circuiting behaviour, making
     #  > it appropriate for cryptography

--- a/PA193_mnemonic_Slytherin/mnemonic.py
+++ b/PA193_mnemonic_Slytherin/mnemonic.py
@@ -96,7 +96,7 @@ def _secure_seed_compare(expected_seed: bytes, actual_seed: bytes) -> bool:
     #  > and lengths of a and b—but not their values.
     #
     # Type and length of seeds is known to the attacker, but not the value of expected seed.
-    if not (type(expected_seed) == type(actual_seed) == bytes):
+    if not (isinstance(expected_seed, bytes) and isinstance(actual_seed, bytes)):
         # Function `hmac.compare_digest` accepts strings & bytes and raises TypeError
         # for other types. It would accept two strings, but we accept only two
         # bytes-like objects, therefore we raise TypeError here.

--- a/PA193_mnemonic_Slytherin/mnemonic.py
+++ b/PA193_mnemonic_Slytherin/mnemonic.py
@@ -9,6 +9,7 @@ Team Slytherin: @sobuch, @lsolodkova, @mvondracek.
 
 2019
 """
+import hmac
 import logging
 from typing import Tuple
 
@@ -72,12 +73,29 @@ def __is_valid_seed(seed: bytes) -> bool:
     pass
 
 
-def __secure_seed_compare(expected_seed: bytes, actual_seed: bytes) -> bool:
+def _secure_seed_compare(expected_seed: bytes, actual_seed: bytes) -> bool:
     """Compare provided seeds in constant time to prevent timing attacks.
+    :raises TypeError: if parameters are not bytes-like objects
     :rtype: bool
     :return: True if seeds are the same, False otherwise.
     """
-    pass
+    # TODO: Can we use `hmac` module?
+    # > hmac.compare_digest` uses an approach designed to prevent timing
+    # > analysis by avoiding content-based short circuiting behaviour, making
+    #  > it appropriate for cryptography
+    # > https://docs.python.org/3.7/library/hmac.html#hmac.compare_digest
+    #
+    # > Note: If a and b are of different lengths, or if an error occurs,
+    # > a timing attack could theoretically reveal information about the types
+    #  > and lengths of a and b—but not their values.
+    #
+    # Type and length of seeds is known to the attacker, but not the value of expected seed.
+    if not (type(expected_seed) == type(actual_seed) == bytes):
+        # Function `hmac.compare_digest` accepts strings & bytes and raises TypeError
+        # for other types. It would accept two strings, but we accept only two
+        # bytes-like objects, therefore we raise TypeError here.
+        raise TypeError('a bytes-like object is required')
+    return hmac.compare_digest(expected_seed, actual_seed)
 
 
 def generate(entropy: bytes, seed_password: str = '') -> Tuple[str, bytes]:

--- a/PA193_mnemonic_Slytherin/tests/test_mnemonic.py
+++ b/PA193_mnemonic_Slytherin/tests/test_mnemonic.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from PA193_mnemonic_Slytherin.mnemonic import do_some_work
+from PA193_mnemonic_Slytherin.mnemonic import do_some_work, _secure_seed_compare
 
 
 class TestDoSomeWork(TestCase):
@@ -10,3 +10,26 @@ class TestDoSomeWork(TestCase):
         """Placeholder for initial code structure."""
         self.assertTrue(do_some_work(1))
         self.assertFalse(do_some_work(123))
+
+
+class TestMnemonicInternal(TestCase):
+    def test_secure_seed_compare(self):
+        seed = b'\x27\x4d\xdc\x52\x58\x02\xf7\xc8\x28\xd8\xef\x7d\xdb\xcd\xc5' \
+               b'\x30\x4e\x87\xac\x35\x35\x91\x36\x11\xfb\xbf\xa9\x86\xd0\xc9' \
+               b'\xe5\x47\x6c\x91\x68\x9f\x9c\x8a\x54\xfd\x55\xbd\x38\x60\x6a' \
+               b'\xa6\xa8\x59\x5a\xd2\x13\xd4\xc9\xc9\xf9\xac\xa3\xfb\x21\x70' \
+               b'\x69\xa4\x10\x28'
+        self.assertTrue(_secure_seed_compare(seed, seed))
+        self.assertTrue(_secure_seed_compare(b'', b''))
+        self.assertFalse(_secure_seed_compare(seed, b'\x00'))
+        self.assertFalse(_secure_seed_compare(b'\x00', seed))
+        self.assertFalse(_secure_seed_compare(seed, b''))
+        with self.assertRaises(TypeError):
+            # noinspection PyTypeChecker
+            _secure_seed_compare(seed, None)
+        with self.assertRaises(TypeError):
+            # noinspection PyTypeChecker
+            _secure_seed_compare(None, seed)
+        with self.assertRaises(TypeError):
+            # noinspection PyTypeChecker
+            _secure_seed_compare('text', 'text')


### PR DESCRIPTION
Implementation of `_secure_seed_compare`.

I've just created new issue #16 concerning use of `hmac` module from Python's standard library.