### PR TITLE
typo: docs: mnemoniccli.Config.Format used only forentropy and seed, …

### DIFF
--- a/PA193_mnemonic_Slytherin/mnemoniccli.py
+++ b/PA193_mnemonic_Slytherin/mnemoniccli.py
@@ -188,7 +188,7 @@ def main(argv) -> ExitCode:
 class Config(object):
     @unique
     class Format(Enum):
-        """Formats for reading and writing entropy, seed, and mnemonic phrase."""
+        """Formats for reading and writing entropy and seed."""
         BINARY = 'bin'
         TEXT_HEXADECIMAL = 'hex'
 


### PR DESCRIPTION
…not for mnemonic phrase.